### PR TITLE
[feat] 게시글 발행/재발행 기준 잔디 집계 로직 정비

### DIFF
--- a/LogLog_back/src/main/java/com/example/loglog/controller/MyPageController.java
+++ b/LogLog_back/src/main/java/com/example/loglog/controller/MyPageController.java
@@ -1,10 +1,8 @@
 package com.example.loglog.controller;
 
 import com.example.loglog.dto.response.GrassResponse;
-import com.example.loglog.dto.response.MyCommentResponse;
 import com.example.loglog.dto.response.MyPostResponse;
 import com.example.loglog.service.GrassService;
-import com.example.loglog.service.LogService;
 import com.example.loglog.service.MyPageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,7 +15,6 @@ import java.util.List;
 @RequestMapping("/api/mypage")
 public class MyPageController {
 
-    private final LogService logService;
     private final GrassService grassService;
     private final MyPageService myPageService;
 
@@ -35,7 +32,7 @@ public class MyPageController {
             @RequestParam int year,
             @AuthenticationPrincipal Long userId
     ) {
-        return logService.getGrass(userId, year);
+        return grassService.getGrassByYear(userId, year);
     }
 
     // 잔디 연도 리스트

--- a/LogLog_back/src/main/java/com/example/loglog/entity/Post.java
+++ b/LogLog_back/src/main/java/com/example/loglog/entity/Post.java
@@ -60,6 +60,9 @@ public class Post {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
     // ManyToMany → 중간엔티티 방식
     @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -96,5 +99,10 @@ public class Post {
         this.thumbnailUrl = thumbnailUrl;
         this.category = category;
         this.status = status;
+    }
+
+    public void publishNow() {
+        this.status = PostStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
     }
 }

--- a/LogLog_back/src/main/java/com/example/loglog/repository/LogRepository.java
+++ b/LogLog_back/src/main/java/com/example/loglog/repository/LogRepository.java
@@ -11,7 +11,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface LogRepository extends JpaRepository<Log, Long> {
-    // 로그인 1일 1회 체크용
+
+    // 로그인 1일 1회 체크
     boolean existsByUserAndActivityTypeAndCreatedAtBetween(
             User user,
             ActivityType activityType,
@@ -19,27 +20,8 @@ public interface LogRepository extends JpaRepository<Log, Long> {
             LocalDateTime end
     );
 
-    // 잔디 집계용 (최근 1년)
+    // 잔디 집계 (연도 / 최근 1년 공용)
     @Query(value = """
-            SELECT
-                TRUNC(created_at),
-                COUNT(*)
-            FROM log_log
-            WHERE user_id = :userId
-              AND created_at BETWEEN :startDate AND :endDate
-            GROUP BY TRUNC(created_at)
-            ORDER BY TRUNC(created_at)
-        """,
-            nativeQuery = true
-    )
-    List<Object[]> countDailyActivities(
-            @Param("userId") Long userId,
-            @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate
-    );
-
-    @Query(
-            value = """
             SELECT
                 TRUNC(created_at),
                 COUNT(*)
@@ -57,6 +39,7 @@ public interface LogRepository extends JpaRepository<Log, Long> {
             @Param("endDate") LocalDateTime endDate
     );
 
+    // 잔디 연도 목록
     @Query(
             value = """
             SELECT DISTINCT EXTRACT(YEAR FROM created_at) AS y
@@ -67,5 +50,4 @@ public interface LogRepository extends JpaRepository<Log, Long> {
             nativeQuery = true
     )
     List<Number> findActivityYears(@Param("userId") Long userId);
-
 }

--- a/LogLog_back/src/main/java/com/example/loglog/service/GrassService.java
+++ b/LogLog_back/src/main/java/com/example/loglog/service/GrassService.java
@@ -12,33 +12,35 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class GrassService {
+
     private final LogRepository logRepository;
 
+    // 연도별 잔디
     public List<GrassResponse> getGrassByYear(Long userId, int year) {
         LocalDateTime start = LocalDate.of(year, 1, 1).atStartOfDay();
-        LocalDateTime end = LocalDate.of(year, 12, 31).atTime(23, 59, 59);
+        LocalDateTime end = LocalDate.of(year + 1, 1, 1).atStartOfDay();
 
         return toGrassResponses(
                 logRepository.countDailyActivitiesBetween(userId, start, end)
         );
     }
 
-    // 잔디 기본 화면: 오늘 기준 최근 1년(365일)
+    // 기본 화면: 오늘 포함 최근 365일
     public List<GrassResponse> getGrassRecent(Long userId) {
-        // 오늘 포함 365일: (today - 364) ~ today
         LocalDate today = LocalDate.now();
         LocalDate startDate = today.minusDays(364);
 
         LocalDateTime start = startDate.atStartOfDay();
-        LocalDateTime end = today.atTime(23, 59, 59);
+        LocalDateTime end = today.plusDays(1).atStartOfDay();
 
         return toGrassResponses(
                 logRepository.countDailyActivitiesBetween(userId, start, end)
         );
     }
 
+    // 잔디가 존재하는 연도 목록
     public List<Integer> getGrassYears(Long userId) {
         return logRepository.findActivityYears(userId)
                 .stream()
@@ -49,9 +51,11 @@ public class GrassService {
     private List<GrassResponse> toGrassResponses(List<Object[]> rows) {
         return rows.stream()
                 .map(row -> {
-                    LocalDate date = ((java.sql.Timestamp) row[0])
-                            .toLocalDateTime()
-                            .toLocalDate();
+                    LocalDate date =
+                            ((java.sql.Timestamp) row[0])
+                                    .toLocalDateTime()
+                                    .toLocalDate();
+
                     long count = ((Number) row[1]).longValue();
                     return new GrassResponse(date, count);
                 })

--- a/LogLog_back/src/main/java/com/example/loglog/service/LogService.java
+++ b/LogLog_back/src/main/java/com/example/loglog/service/LogService.java
@@ -1,8 +1,6 @@
 package com.example.loglog.service;
 
-import com.example.loglog.dto.response.GrassResponse;
 import com.example.loglog.dto.type.ActivityType;
-import com.example.loglog.dto.type.PostStatus;
 import com.example.loglog.entity.Log;
 import com.example.loglog.entity.User;
 import com.example.loglog.repository.LogRepository;
@@ -10,24 +8,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LogService {
+
     private final LogRepository logRepository;
 
-    // 로그인 로그
+    // 로그인 로그 (1일 1회)
     public void recordLogin(User user) {
         LocalDate today = LocalDate.now();
-        LocalDateTime start = today.atStartOfDay();          // 오늘 자정
-        LocalDateTime end = today.plusDays(1).atStartOfDay(); // 내일 자정
+        LocalDateTime start = today.atStartOfDay();
+        LocalDateTime end = today.plusDays(1).atStartOfDay();
 
-        // 로그인 여부 판단
         boolean alreadyLoggedToday =
                 logRepository.existsByUserAndActivityTypeAndCreatedAtBetween(
                         user,
@@ -36,82 +32,16 @@ public class LogService {
                         end
                 );
 
-        if (alreadyLoggedToday) {
-            return; // 오늘 이미 찍힘 → 아무 것도 안 함
-        }
+        if (alreadyLoggedToday) return;
 
-        // 최초 로그인이면 활동 저장
-        logRepository.save(
-                Log.builder()
-                        .user(user)
-                        .activityType(ActivityType.LOGIN)
-                        .build()
-        );
+        logRepository.save(Log.login(user));
     }
 
     // 포스트 발행 로그
-    public void recordPostPublish(
-            User user,
-            PostStatus oldStatus,
-            PostStatus newStatus,
-            Long postId
-    ) {
-        // 임시저장은 무조건 제외
-        if (newStatus == PostStatus.DRAFT) {
-            return;
-        }
-        // 첫 발행 (DRAFT → 발행 : 로그)
-        if (oldStatus == PostStatus.DRAFT
-                && (newStatus == PostStatus.PUBLISHED || newStatus == PostStatus.PRIVATE)) {
-
-            logRepository.save(
-                    Log.builder()
-                            .user(user)
-                            .activityType(ActivityType.POST_PUBLISH)
-                            .postId(postId)
-                            .build()
-            );
-            return;
-        }
-        // 수정 후 발행 (PUBLISHED / PRIVATE → 다시 발행)
-        if ((oldStatus == PostStatus.PUBLISHED || oldStatus == PostStatus.PRIVATE)
-                && (newStatus == PostStatus.PUBLISHED || newStatus == PostStatus.PRIVATE)) {
-
-            logRepository.save(
-                    Log.builder()
-                            .user(user)
-                            .activityType(ActivityType.POST_PUBLISH)
-                            .postId(postId)
-                            .build()
-            );
-        }
+    // 발행 버튼 API에서만 호출할 것
+    public void recordPostPublish(User user, Long postId) {
+        logRepository.save(
+                Log.postPublish(user, postId)
+        );
     }
-
-    // 잔디 조회
-    @Transactional(readOnly = true)
-    public List<GrassResponse> getGrass(Long userId, int year) {
-
-        LocalDateTime start =
-                LocalDate.of(year, 1, 1).atStartOfDay();
-
-        LocalDateTime end =
-                LocalDate.of(year, 12, 31).atTime(23, 59, 59);
-
-        return logRepository.countDailyActivities(
-                        userId,
-                        start,
-                        end
-                ).stream()
-                .map(row -> {
-                    LocalDate date =
-                            ((Timestamp) row[0]).toLocalDateTime().toLocalDate();
-
-                    long count =
-                            ((Number) row[1]).longValue();
-
-                    return new GrassResponse(date, count);
-                })
-                .toList();
-    }
-
 }

--- a/LogLog_back/src/main/java/com/example/loglog/service/PostService.java
+++ b/LogLog_back/src/main/java/com/example/loglog/service/PostService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,21 +44,22 @@ public class PostService {
         Category category = categoryRepository.findById(request.getCategoryId())
                 .orElseThrow(() -> new IllegalArgumentException("카테고리가 없습니다."));
 
-        // 게시글 먼저 저장
-        Post post = postRepository.save(request.toEntity(user, category));
+        Post post = request.toEntity(user, category);
 
-        // 태그 매핑
+        // 생성 + 발행인 경우
+        if (request.getStatus() == PostStatus.PUBLISHED) {
+            post.publishNow(); // status + publishedAt
+        }
+
+        postRepository.save(post);
+
         addTags(post, request.getTags());
 
-        // 발행인 경우만 로그 (임시저장은 집계 X)
-        if (post.getStatus() != PostStatus.DRAFT) {
-            logService.recordPostPublish(
-                    user,
-                    PostStatus.DRAFT,      // 생성은 항상 DRAFT에서 시작
-                    post.getStatus(),
-                    post.getId()
-            );
+        // 발행 버튼을 눌렀을 때만 로그
+        if (post.getStatus() == PostStatus.PUBLISHED) {
+            logService.recordPostPublish(user, post.getId());
         }
+
         return post.getId();
     }
 
@@ -171,6 +173,7 @@ public class PostService {
      ============================ */
     @Transactional
     public Long updatePost(Long postId, PostUpdateRequest request, Long userId) {
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
 
@@ -178,23 +181,20 @@ public class PostService {
             throw new IllegalStateException("수정 권한이 없습니다.");
         }
 
-        // update 전에 상태 백업
-        PostStatus oldStatus = post.getStatus();
-
         Category category = categoryRepository.findById(request.getCategoryId())
                 .orElseThrow(() -> new IllegalArgumentException("카테고리가 없습니다."));
 
-        // 게시글 수정 (status 포함)
+        // 수정 + 재발행
         post.update(
                 request.getTitle(),
                 request.getContent(),
                 request.getThumbnailUrl(),
                 category,
-                request.getStatus()
+                PostStatus.PUBLISHED
         );
-    /* ============================
-       게시글 히스토리
-     ============================ */
+
+        post.publishNow(); // 재발행 시각 갱신
+
         PostHistory history = PostHistory.builder()
                 .post(post)
                 .userId(userId)
@@ -202,22 +202,20 @@ public class PostService {
                 .content(post.getContent())
                 .thumbnailUrl(post.getThumbnailUrl())
                 .status(post.getStatus())
-                .categoryId(post.getCategory() != null ? post.getCategory().getCategoryId() : null)
+                .categoryId(
+                        post.getCategory() != null
+                                ? post.getCategory().getCategoryId()
+                                : null
+                )
                 .build();
 
         postHistoryRepository.save(history);
 
-
         post.clearTags();
-        addTags(post, request.getTags()); // 아까 만든 addTags 메서드 재활용
+        addTags(post, request.getTags());
 
-        // 수정 후 발행 로그
-        logService.recordPostPublish(
-                post.getUser(),
-                oldStatus,
-                post.getStatus(),
-                post.getId()
-        );
+        // 재발행 로그
+        logService.recordPostPublish(post.getUser(), post.getId());
 
         return post.getId();
     }


### PR DESCRIPTION
## 📌 작업 개요
게시글 잔디 집계를 **상태 변화가 아닌 발행 이벤트 기준**으로 재설계했습니다.  
발행/재발행 시점이 명확히 기록되도록 `publishedAt`과 로그 구조를 정비했습니다.

---

## ✨ 주요 변경 사항

### 1. 게시글 발행 시점 명확화
- `Post.publishedAt` 필드 추가
- `publishNow()` 메서드 도입
  - 발행 / 재발행 시점에만 시간 갱신
  - 임시저장(DRAFT)에는 영향 없음

### 2. 잔디 로그 정책 정리
- `POST_PUBLISH` 로그는 **발행 버튼 클릭 시에만 기록**
- 수정 화면에서도 발행 버튼만 존재 → 수정 = 재발행으로 처리
- 로그인은 1일 1회만 로그 기록

### 3. 서비스 책임 분리
- `LogService` : 활동 로그 기록 전담
- `GrassService` : 잔디 집계/조회 전담
- `MyPageController`에서 잔디 조회는 `GrassService`만 사용

### 4. 과거 데이터 보정
- 기존 `PUBLISHED` 게시글에 대해  
  `published_at = created_at` 보정
- 과거 게시글 발행 로그(POST_PUBLISH) 백필 완료

---

## 🧪 확인 사항
- [x] 기존 게시글 잔디 정상 표시
- [x] 신규 발행 시 잔디 즉시 반영
- [x] 수정 후 발행 시 잔디 증가
- [x] 임시저장 글은 집계 제외
- [x] 로그인 잔디 1일 1회 유지

---

## 📎 참고
- 잔디 집계는 `log_log.created_at` 기준으로 날짜별 group by
- 프론트에서는 날짜 range 기준으로 0 count 날짜도 강제 생성 필요
